### PR TITLE
Log remitos to spreadsheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,43 @@
+# Tres Senderos Invoice Records
+
+The app writes generated remitos to a worksheet named **Remitos** in the
+main Google spreadsheet. The sheet contains the following columns in order:
+
+1. **Number** – Remito or invoice number.
+2. **Date** – Date of issuance (`YYYY-MM-DD`).
+3. **Customer name** – Name of the client.
+4. **Subtotal** – Sum of line item subtotals.
+5. **Discount** – Amount discounted from the subtotal.
+6. **Total final** – `Subtotal - Discount`.
+
+Each time a remito is generated, these values are appended as a new row. You
+can analyse revenue directly in Google Sheets or with pandas.
+
+## Google Sheets totals
+
+To compute the total revenue for a month use a formula such as:
+
+```none
+=SUMIFS('Remitos'!F:F, 'Remitos'!B:B, ">=2024-04-01", 'Remitos'!B:B, "<=2024-04-30")
+```
+
+Replace the dates with the desired range. Column **F** corresponds to
+`Total final`.
+
+## Using pandas
+
+```python
+import pandas as pd
+from sheet_connector import SheetConnector
+
+connector = SheetConnector(SPREADSHEET_URL)
+df = connector.client.open_by_url(SPREADSHEET_URL).worksheet("Remitos").get_all_records()
+df = pd.DataFrame(df)
+monthly_total = (
+    df.assign(Date=pd.to_datetime(df["Date"]))
+      .query("Date.dt.month == 4 and Date.dt.year == 2024")
+      ["Total final"].sum()
+)
+```
+
+This will give the total for April 2024.

--- a/pages/2_Remito.py
+++ b/pages/2_Remito.py
@@ -3,6 +3,9 @@ import pandas as pd
 import datetime
 from io import BytesIO
 from invoice_manager import InvoiceManager  # Tu clase POO
+from sheet_connector import SheetConnector
+
+SPREADSHEET_URL = "https://docs.google.com/spreadsheets/d/1i4kafAJQvVkKbkVIo5LldsN7R-ApeWhHDKZjBvsguoo/edit?gid=0#gid=0"
 
 def remito_integration_page():
     st.title("Generar Remito con Productos Existentes")
@@ -148,6 +151,7 @@ def remito_integration_page():
 
             # Calculamos el monto de descuento
             discount_amount = subtotal * discount_percent / 100
+            total_final = subtotal - discount_amount
 
             # Para que aparezca "Descuento (10%)" en la línea de subtotales,
             # renombramos discounts_title con el porcentaje:
@@ -185,6 +189,17 @@ def remito_integration_page():
                 st.session_state["remito_pdf"] = pdf_bytes
                 st.session_state["remito_file_name"] = f"{remito_number}.pdf"
                 st.success("¡Remito generado exitosamente!")
+
+                invoice_record = {
+                    "Number": remito_number,
+                    "Date": remito_date.strftime("%Y-%m-%d"),
+                    "Customer name": to_,
+                    "Subtotal": subtotal,
+                    "Discount": discount_amount,
+                    "Total final": total_final,
+                }
+                connector = SheetConnector(SPREADSHEET_URL)
+                connector.append_invoice_record(invoice_record)
             except Exception as e:
                 st.error(f"Error al generar el remito: {e}")
                 st.session_state["remito_pdf"] = None

--- a/sheet_connector.py
+++ b/sheet_connector.py
@@ -91,6 +91,24 @@ class SheetConnector:
         for row_num in rows_to_delete:
             sheet.delete_rows(row_num)
 
+    def append_invoice_record(self, record: dict, sheet_name="Remitos"):
+        """Append an invoice/remito record to the specified worksheet.
+
+        If the worksheet does not exist, it will be created and the keys of
+        ``record`` will be written as the header in the first row.
+        """
+        spreadsheet = self.client.open_by_url(self.spreadsheet_url)
+
+        try:
+            worksheet = spreadsheet.worksheet(sheet_name)
+        except gspread.exceptions.WorksheetNotFound:
+            worksheet = spreadsheet.add_worksheet(
+                title=sheet_name, rows="1", cols=str(len(record))
+            )
+            worksheet.append_row(list(record.keys()))
+
+        worksheet.append_row(list(record.values()))
+
 def update_spreadsheet(spreadsheet_url, df):
     connector = SheetConnector(spreadsheet_url)
     connector.update_data(df)


### PR DESCRIPTION
## Summary
- add `SheetConnector.append_invoice_record` for logging invoice rows
- record remitos in a new `Remitos` worksheet from the PDF generation page
- calculate `total_final` in the remito page
- document the new worksheet and how to obtain totals with Sheets or pandas

## Testing
- `python -m py_compile sheet_connector.py pages/2_Remito.py invoice_manager.py category_manager.py Gestionar_Productos.py`

------
https://chatgpt.com/codex/tasks/task_e_68405f381a00832b821d5625cb4a16b8