### PR TITLE
Log remitos to spreadsheet

### DIFF
--- a/Gestionar_Productos.py
+++ b/Gestionar_Productos.py
@@ -4,6 +4,7 @@ import pandas as pd
 import concurrent.futures
 
 from sheet_connector import get_data_from_sheet, update_spreadsheet
+from config import SPREADSHEET_URL
 from product_editor import ProductEditor
 from product_manager import ProductManager
 from category_manager import CategoryManager
@@ -11,8 +12,6 @@ from category_manager import CategoryManager
 st.set_page_config(page_title="Gestión de Productos", layout="wide") # Única llamada a set_page_config
 
 st.title("Gestión de Productos")
-
-SPREADSHEET_URL = "https://docs.google.com/spreadsheets/d/1i4kafAJQvVkKbkVIo5LldsN7R-ApeWhHDKZjBvsguoo/edit?gid=0#gid=0"
 
 df = get_data_from_sheet(SPREADSHEET_URL)
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,47 @@
+# Tres Senderos Invoice Records
+
+The app writes generated remitos to a worksheet named **Remitos** in the
+main Google spreadsheet. The sheet contains the following columns in order:
+
+1. **Number** – Remito or invoice number.
+2. **Date** – Date of issuance (`YYYY-MM-DD`).
+3. **Customer name** – Name of the client.
+4. **Subtotal** – Sum of line item subtotals.
+5. **Discount** – Amount discounted from the subtotal.
+6. **Total final** – `Subtotal - Discount`.
+
+Each time a remito is generated, these values are appended as a new row. You
+can analyse revenue directly in Google Sheets or with pandas.
+
+If the **Remitos** worksheet does not exist or is empty, the app will
+automatically create it and insert this header row.
+
+## Google Sheets totals
+
+To compute the total revenue for a month use a formula such as:
+
+```none
+=SUMIFS('Remitos'!F:F, 'Remitos'!B:B, ">=2024-04-01", 'Remitos'!B:B, "<=2024-04-30")
+```
+
+Replace the dates with the desired range. Column **F** corresponds to
+`Total final`.
+
+## Using pandas
+
+```python
+import pandas as pd
+from sheet_connector import SheetConnector
+from config import SPREADSHEET_URL
+
+connector = SheetConnector(SPREADSHEET_URL)
+df = connector.client.open_by_url(SPREADSHEET_URL).worksheet("Remitos").get_all_records()
+df = pd.DataFrame(df)
+monthly_total = (
+    df.assign(Date=pd.to_datetime(df["Date"]))
+      .query("Date.dt.month == 4 and Date.dt.year == 2024")
+      ["Total final"].sum()
+)
+```
+
+This will give the total for April 2024.

--- a/category_manager.py
+++ b/category_manager.py
@@ -1,6 +1,8 @@
 # category_manager.py
 import streamlit as st
 import pandas as pd
+from config import SPREADSHEET_URL
+from sheet_connector import SheetConnector
 
 class CategoryManager:
     def __init__(self):
@@ -58,8 +60,6 @@ class CategoryManager:
                 st.dataframe(st.session_state.df)
                 
                 # Actualizar el spreadsheet eliminando las filas correspondientes a la categoría
-                SPREADSHEET_URL = "https://docs.google.com/spreadsheets/d/1i4kafAJQvVkKbkVIo5LldsN7R-ApeWhHDKZjBvsguoo/edit?gid=0#gid=0"
-                from sheet_connector import SheetConnector
                 connector = SheetConnector(SPREADSHEET_URL)
                 connector.delete_category_rows(cat_to_delete)
 

--- a/config.py
+++ b/config.py
@@ -1,0 +1,1 @@
+SPREADSHEET_URL = "https://docs.google.com/spreadsheets/d/1i4kafAJQvVkKbkVIo5LldsN7R-ApeWhHDKZjBvsguoo/edit?gid=0#gid=0"

--- a/pages/2_Remito.py
+++ b/pages/2_Remito.py
@@ -3,6 +3,8 @@ import pandas as pd
 import datetime
 from io import BytesIO
 from invoice_manager import InvoiceManager  # Tu clase POO
+from sheet_connector import SheetConnector
+from config import SPREADSHEET_URL
 
 def remito_integration_page():
     st.title("Generar Remito con Productos Existentes")
@@ -148,6 +150,7 @@ def remito_integration_page():
 
             # Calculamos el monto de descuento
             discount_amount = subtotal * discount_percent / 100
+            total_final = subtotal - discount_amount
 
             # Para que aparezca "Descuento (10%)" en la línea de subtotales,
             # renombramos discounts_title con el porcentaje:
@@ -185,6 +188,17 @@ def remito_integration_page():
                 st.session_state["remito_pdf"] = pdf_bytes
                 st.session_state["remito_file_name"] = f"{remito_number}.pdf"
                 st.success("¡Remito generado exitosamente!")
+
+                invoice_record = {
+                    "Number": remito_number,
+                    "Date": remito_date.strftime("%Y-%m-%d"),
+                    "Customer name": to_,
+                    "Subtotal": subtotal,
+                    "Discount": discount_amount,
+                    "Total final": total_final,
+                }
+                connector = SheetConnector(SPREADSHEET_URL)
+                connector.append_invoice_record(invoice_record)
             except Exception as e:
                 st.error(f"Error al generar el remito: {e}")
                 st.session_state["remito_pdf"] = None

--- a/sheet_connector.py
+++ b/sheet_connector.py
@@ -91,6 +91,28 @@ class SheetConnector:
         for row_num in rows_to_delete:
             sheet.delete_rows(row_num)
 
+    def append_invoice_record(self, record: dict, sheet_name="Remitos"):
+        """Append an invoice/remito record to the specified worksheet.
+
+        If the worksheet does not exist, it will be created and the keys of
+        ``record`` will be written as the header in the first row.
+        """
+        spreadsheet = self.client.open_by_url(self.spreadsheet_url)
+
+        try:
+            worksheet = spreadsheet.worksheet(sheet_name)
+        except gspread.exceptions.WorksheetNotFound:
+            worksheet = spreadsheet.add_worksheet(
+                title=sheet_name, rows="1", cols=str(len(record))
+            )
+            worksheet.append_row(list(record.keys()))
+        else:
+            # Ensure header row exists for previously created empty sheets
+            if not worksheet.get_all_values():
+                worksheet.append_row(list(record.keys()))
+
+        worksheet.append_row(list(record.values()))
+
 def update_spreadsheet(spreadsheet_url, df):
     connector = SheetConnector(spreadsheet_url)
     connector.update_data(df)


### PR DESCRIPTION
## Summary
- add `SheetConnector.append_invoice_record` for logging invoice rows
- record remitos in a new `Remitos` worksheet from the PDF generation page
- calculate `total_final` in the remito page
- document the new worksheet and how to obtain totals with Sheets or pandas
- centralize `SPREADSHEET_URL` configuration in `config.py`

## Testing
- `python -m py_compile sheet_connector.py pages/2_Remito.py invoice_manager.py category_manager.py Gestionar_Productos.py`


------
https://chatgpt.com/codex/tasks/task_e_68405f381a00832b821d5625cb4a16b8